### PR TITLE
test(e2e): running tests on travis

### DIFF
--- a/.config/nightwatch.ts
+++ b/.config/nightwatch.ts
@@ -14,6 +14,10 @@ export = (function (settings) {
   if (process.env.SELENIUM_PORT)
     settings.selenium.host = process.env.SELENIUM_PORT;
 
+  if (process.env.TRAVIS)
+    settings.test_settings.default.desiredCapabilities.chromeOptions =
+      { args : ['--no-sandbox'] };
+
   settings.page_objects_path = './tests/.tmp/page-objects';
 
   return settings;

--- a/.config/nightwatch.ts
+++ b/.config/nightwatch.ts
@@ -1,7 +1,3 @@
-const config = process.env.LOCAL
-  ? require('./nightwatch/local.ts')
-  : require('./nightwatch/sauce.ts');
-
 module.exports = (function (settings) {
   if (process.platform === 'win32')
     settings.selenium.cli_args['webdriver.chrome.driver'] =
@@ -21,4 +17,4 @@ module.exports = (function (settings) {
   settings.page_objects_path = './tests/.tmp/page-objects';
 
   return settings;
-})(config);
+})(process.env.LOCAL ? require('./nightwatch/local.ts') : require('./nightwatch/sauce.ts'));

--- a/.config/nightwatch.ts
+++ b/.config/nightwatch.ts
@@ -2,7 +2,7 @@ const config = process.env.LOCAL
   ? require('./nightwatch/local.ts')
   : require('./nightwatch/sauce.ts');
 
-export = (function (settings) {
+module.exports = (function (settings) {
   if (process.platform === 'win32')
     settings.selenium.cli_args['webdriver.chrome.driver'] =
       './node_modules/.bin/chromedriver.cmd';

--- a/.config/nightwatch/local.ts
+++ b/.config/nightwatch/local.ts
@@ -32,7 +32,7 @@ const config = {
         acceptSslCerts: true,
       },
       globals: {
-        waitForConditionTimeout: 10000,
+        waitForConditionTimeout: 20000,
       },
     },
   },

--- a/.config/nightwatch/local.ts
+++ b/.config/nightwatch/local.ts
@@ -40,9 +40,9 @@ const config = {
     firefox: {
       desiredCapabilities: {
         browserName: 'firefox',
-      }
-    }
+      },
+    },
   },
 };
 
-export = config;
+module.exports = config;

--- a/.config/nightwatch/local.ts
+++ b/.config/nightwatch/local.ts
@@ -21,6 +21,7 @@ const config = {
       selenium_port: 4444,
       selenium_host: 'localhost',
       output_folder: './report',
+      firefox_profile: false,
       screenshots: {
         enabled: true,
         path: '.screens',

--- a/.config/nightwatch/local.ts
+++ b/.config/nightwatch/local.ts
@@ -10,6 +10,7 @@ const config = {
     port: 4444,
     cli_args: {
       'webdriver.chrome.driver': './node_modules/.bin/chromedriver',
+      'webdriver.gecko.driver': './node_modules/.bin/geckodriver',
       'webdriver.ie.driver': '',
     },
   },
@@ -35,6 +36,12 @@ const config = {
         waitForConditionTimeout: 20000,
       },
     },
+
+    firefox: {
+      desiredCapabilities: {
+        browserName: 'firefox',
+      }
+    }
   },
 };
 

--- a/.config/nightwatch/local.ts
+++ b/.config/nightwatch/local.ts
@@ -21,7 +21,6 @@ const config = {
       selenium_port: 4444,
       selenium_host: 'localhost',
       output_folder: './report',
-      firefox_profile: false,
       screenshots: {
         enabled: true,
         path: '.screens',
@@ -41,6 +40,8 @@ const config = {
     firefox: {
       desiredCapabilities: {
         browserName: 'firefox',
+        javascriptEnabled: true,
+        acceptSslCerts: true,
       },
     },
   },

--- a/.config/nightwatch/local.ts
+++ b/.config/nightwatch/local.ts
@@ -15,6 +15,8 @@ const config = {
     },
   },
 
+  test_workers: true,
+
   test_settings: {
     default: {
       launch_url: 'http://localhost:8080',

--- a/.config/nightwatch/sauce.ts
+++ b/.config/nightwatch/sauce.ts
@@ -1,4 +1,4 @@
-export = {
+module.exports = {
   'src_folders': ['tests/.tmp'],
   'output_folder': 'report',
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,6 @@ before_install:
 
 before_script:
  - npm start &
- - sleep 10
+ - sleep 20
 
 script: npm run test:ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: node_js
 
 dist: trusty
 
+addons:
+  firfox: 'latest'
+
 node_js:
   - 6
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 dist: trusty
 
 addons:
-  firfox: 'latest'
+  firefox: 'latest'
 
 node_js:
   - 6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,18 @@
 language: node_js
+
+dist: trusty
+sudo: required
+
 node_js:
   - 6
+
+before_install:
+ - export CHROME_BIN=/usr/bin/google-chrome
+ - export DISPLAY=:99.0
+ - sh -e /etc/init.d/xvfb start
+ - sudo apt-get update
+ - sudo apt-get install -y libappindicator1 fonts-liberation
+ - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+ - sudo dpkg -i google-chrome*.deb
+
+script: npm run test:ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,8 @@ before_install:
  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
  - sudo dpkg -i google-chrome*.deb
 
+after_install:
+ - npm start &
+ - sleep 10
+
 script: npm run test:ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,14 @@
 language: node_js
 
 dist: trusty
-sudo: required
 
 node_js:
   - 6
 
 before_install:
- - export CHROME_BIN=/usr/bin/google-chrome
+ - export CHROME_BIN=chromium-browser
  - export DISPLAY=:99.0
  - sh -e /etc/init.d/xvfb start
- - sudo apt-get update
- - sudo apt-get install -y libappindicator1 fonts-liberation
- - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
- - sudo dpkg -i google-chrome*.deb
 
 before_script:
  - npm start &

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
  - sudo dpkg -i google-chrome*.deb
 
-after_install:
+before_script:
  - npm start &
  - sleep 10
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ dist: trusty
 node_js:
   - 6
 
+cache:
+  directories:
+  - node_modules
+
 before_install:
  - export CHROME_BIN=chromium-browser
  - export DISPLAY=:99.0

--- a/custom-typings/nightwatch.d.ts
+++ b/custom-typings/nightwatch.d.ts
@@ -1685,5 +1685,8 @@ declare module 'nightwatch' {
     launch_url: string;
   }
 
-  export interface NightWatchBrowser extends NightWatchClient, NightWatchCustomCommands, NightWatchCustomPageObjects, Expect { }
+  export interface NightWatchBrowser extends NightWatchClient, NightWatchCustomCommands, NightWatchCustomPageObjects, Expect
+  {
+    api: NightWatchBrowser;
+  }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "start": "ts-node ./node_modules/.bin/webpack-dev-server --config .config/webpack.config.ts",
     "serve": "npm start",
     "serve-static": "pushstate-server dist 8080",
+    "test:ci": "npm test && npm run test:e2e",
     "test:lint": "tslint src/*.ts src/**/*.ts src/**/**/*.ts src/**/**/**/*.ts src/**/**/**/**/*.ts",
     "test:unit": "npm run clean && mocha-webpack --webpack-config .config/webpack.test.ts 'src/**/*.test.ts'",
     "test:int": "npm run clean && mocha-webpack --webpack-config .config/webpack.int.ts 'src/**/*.int.ts'",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "commit": "git-cz"
   },
   "devDependencies": {
-    "@types/chai": "^3.4.34",
     "@motorcycle/tslint": "^1.3.0",
+    "@types/chai": "^3.4.34",
     "@types/mocha": "^2.2.33",
     "@types/node": "0.0.2",
     "@types/ramda": "0.0.2",
@@ -56,6 +56,7 @@
     "css-loader": "^0.26.1",
     "cz-conventional-changelog": "^1.2.0",
     "firebase-admin": "^4.0.4",
+    "geckodriver": "^1.2.0",
     "ghooks": "^1.3.2",
     "image-webpack-loader": "^3.0.0",
     "mocha": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "start": "ts-node ./node_modules/.bin/webpack-dev-server --config .config/webpack.config.ts",
     "serve": "npm start",
     "serve-static": "pushstate-server dist 8080",
-    "test:ci": "npm test && npm run test:e2e && npm run test:e2e -- -e firefox",
+    "test:ci": "npm test && npm run test:e2e -- -e default,firefox",
     "test:lint": "tslint src/*.ts src/**/*.ts src/**/**/*.ts src/**/**/**/*.ts src/**/**/**/**/*.ts",
     "test:unit": "npm run clean && mocha-webpack --webpack-config .config/webpack.test.ts 'src/**/*.test.ts'",
     "test:int": "npm run clean && mocha-webpack --webpack-config .config/webpack.int.ts 'src/**/*.int.ts'",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "start": "ts-node ./node_modules/.bin/webpack-dev-server --config .config/webpack.config.ts",
     "serve": "npm start",
     "serve-static": "pushstate-server dist 8080",
-    "test:ci": "npm test && npm run test:e2e",
+    "test:ci": "npm test && npm run test:e2e && npm run test:e2e -- -e firefox",
     "test:lint": "tslint src/*.ts src/**/*.ts src/**/**/*.ts src/**/**/**/*.ts src/**/**/**/**/*.ts",
     "test:unit": "npm run clean && mocha-webpack --webpack-config .config/webpack.test.ts 'src/**/*.test.ts'",
     "test:int": "npm run clean && mocha-webpack --webpack-config .config/webpack.int.ts 'src/**/*.int.ts'",

--- a/tests/e2e/identity-and-authorization/connect-with-facebook.test.ts
+++ b/tests/e2e/identity-and-authorization/connect-with-facebook.test.ts
@@ -7,13 +7,12 @@ export = {
   after: deleteFacebookUser,
 
   'Scenario: Connect with Facebook': function (browser: NightWatchBrowser) {
-    (browser.page as any).connect()
-      .navigate()
-      .waitForElementVisible('#page', 1000) // wait for the page to display
+    browser.page.connect().navigate()
+      .waitForElementVisible('.c-btn-federated--facebook') // wait for the page to display
       .click('.c-btn-federated--facebook')
-      .api.pause(2000)
+      .api.pause(10000)
       .assert.urlContains('www.facebook.com/login.php') // we are on the facebook page
-      .waitForElementPresent('#email', 1000)
+      .waitForElementPresent('#email')
       .setValue('#email', process.env.FACEBOOK_TEST_EMAIL)
       .setValue('#pass', process.env.FACEBOOK_TEST_EMAIL_PASSWORD)
       .click('button[type=submit]')

--- a/tests/e2e/identity-and-authorization/connect-with-google.test.ts
+++ b/tests/e2e/identity-and-authorization/connect-with-google.test.ts
@@ -7,11 +7,10 @@ export = {
   after: deleteGoogleUser,
 
   'Scenario: Connect with Google': function (browser: NightWatchBrowser) {
-    browser
-      .url('localhost:8080/connect')
+    browser.page.connect().navigate()
       .waitForElementVisible('#page') // wait for the page to display
       .click('.c-btn-federated--google') // click the google button
-      .pause(5000) // give it time to redirect
+      .api.pause(10000) // give it time to redirect
       .assert.urlContains('ServiceLogin') // we are on the google page
       .waitForElementPresent('#Email')
       .setValue('#Email', process.env.GOOGLE_TEST_EMAIL)

--- a/tests/e2e/identity-and-authorization/sign-in-with-facebook.test.ts
+++ b/tests/e2e/identity-and-authorization/sign-in-with-facebook.test.ts
@@ -9,7 +9,7 @@ export = {
       .navigate()
       .waitForElementVisible('#page') // wait for the page to display
       .click('.c-btn-federated--facebook')
-      .waitForElementPresent('#email', 1000)
+      .waitForElementPresent('#email')
       .setValue('#email', process.env.FACEBOOK_TEST_EMAIL)
       .setValue('#pass', process.env.FACEBOOK_TEST_EMAIL_PASSWORD)
       .click('button[type=submit]')
@@ -19,13 +19,13 @@ export = {
   },
 
   'Scenario: Sign in with Facebook': function (browser: NightWatchBrowser) {
-    (browser.page as any).signin()
+    browser.page.signin()
       .navigate()
-      .waitForElementVisible('#page', 1000) // wait for the page to display
+      .waitForElementVisible('#page') // wait for the page to display
       .click('.c-btn-federated--facebook')
-      .api.pause(2000)
+      .api.pause(10000)
       .assert.urlContains('www.facebook.com/login.php') // we are on the facebook page
-      .waitForElementPresent('#email', 1000)
+      .waitForElementPresent('#email')
       .setValue('#email', process.env.FACEBOOK_TEST_EMAIL)
       .setValue('#pass', process.env.FACEBOOK_TEST_EMAIL_PASSWORD)
       .click('button[type=submit]')

--- a/tests/e2e/identity-and-authorization/sign-in-with-google.test.ts
+++ b/tests/e2e/identity-and-authorization/sign-in-with-google.test.ts
@@ -22,11 +22,11 @@ export = {
 
   'Scenario: Sign in with Google': function (browser: NightWatchBrowser) {
 
-    (browser.page as any).signin()
+    browser.page.signin()
       .navigate()
       .waitForElementVisible('#page') // wait for the page to display
       .click('.c-btn-federated--google')
-      .api.pause(2000)
+      .api.pause(10000)
       .assert.urlContains('ServiceLogin') // we are on the google page
       .waitForElementPresent('#Email')
       .setValue('#Email', process.env.GOOGLE_TEST_EMAIL)

--- a/tests/e2e/identity-and-authorization/switch-to-connect.test.ts
+++ b/tests/e2e/identity-and-authorization/switch-to-connect.test.ts
@@ -3,7 +3,7 @@ import { NightWatchBrowser } from 'nightwatch';
 export = {
   'Scenario: Switch to connect URL': function (browser: NightWatchBrowser) {
     browser
-      .url('localhost:8080/signin')
+      .url('http://localhost:8080/signin')
       .waitForElementVisible('#page', 1000) // wait for the page to display
       .click(`a[href^='/connect']`)
       .waitForElementPresent('#page', 1000)

--- a/tests/e2e/identity-and-authorization/switch-to-sign-in.test.ts
+++ b/tests/e2e/identity-and-authorization/switch-to-sign-in.test.ts
@@ -3,10 +3,10 @@ import { NightWatchBrowser } from 'nightwatch';
 export = {
   'Scenario: Switch to Sign In URL': function (browser: NightWatchBrowser) {
     browser
-      .url('localhost:8080/connect')
-      .waitForElementVisible('#page', 1000) // wait for the page to display
+      .url('http://localhost:8080/connect')
+      .waitForElementVisible('#page') // wait for the page to display
       .click(`a[href^='/signin']`)
-      .waitForElementPresent('#page', 1000)
+      .waitForElementPresent('#page')
       .assert.urlContains('/signin')
       .end();
   },

--- a/tests/page-objects/connect.ts
+++ b/tests/page-objects/connect.ts
@@ -7,7 +7,7 @@ declare module 'nightwatch' {
 }
 
 export = {
-  url: 'localhost:8080/connect',
+  url: 'http://localhost:8080/connect',
   elements: {
     googleButton: {
       selector: '.c-btn-federated--google',

--- a/tests/page-objects/signin.ts
+++ b/tests/page-objects/signin.ts
@@ -7,7 +7,7 @@ declare module 'nightwatch' {
 }
 
 export = {
-  url: 'localhost:8080/connect',
+  url: 'http://localhost:8080/connect',
   elements: {
     googleButton: {
       selector: '.c-btn-federated--google',


### PR DESCRIPTION
Sets up end-to-end tests to run on Travis CI based on the work @Frikki did in #127 
The tests are run in Chrome and in Firefox to get slightly better coverage.
There is also now caching of `node_modules` to increase build speed drastically!